### PR TITLE
feat: rudimentary support for multiple values files

### DIFF
--- a/cmd/helm-docs/command_line.go
+++ b/cmd/helm-docs/command_line.go
@@ -51,6 +51,7 @@ func newHelmDocsCommand(run func(cmd *cobra.Command, args []string)) (*cobra.Com
 	command.PersistentFlags().StringP("output-file", "o", "README.md", "markdown file path relative to each chart directory to which rendered documentation will be written")
 	command.PersistentFlags().StringP("sort-values-order", "s", document.AlphaNumSortOrder, fmt.Sprintf("order in which to sort the values table (\"%s\" or \"%s\")", document.AlphaNumSortOrder, document.FileSortOrder))
 	command.PersistentFlags().StringSliceP("template-files", "t", []string{"README.md.gotmpl"}, "gotemplate file paths relative to each chart directory from which documentation will be generated")
+	command.PersistentFlags().StringSliceP("custom-values-files", "f", []string{}, "additional values files to search for")
 
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("HELM_DOCS")

--- a/cmd/helm-docs/command_line.go
+++ b/cmd/helm-docs/command_line.go
@@ -51,7 +51,7 @@ func newHelmDocsCommand(run func(cmd *cobra.Command, args []string)) (*cobra.Com
 	command.PersistentFlags().StringP("output-file", "o", "README.md", "markdown file path relative to each chart directory to which rendered documentation will be written")
 	command.PersistentFlags().StringP("sort-values-order", "s", document.AlphaNumSortOrder, fmt.Sprintf("order in which to sort the values table (\"%s\" or \"%s\")", document.AlphaNumSortOrder, document.FileSortOrder))
 	command.PersistentFlags().StringSliceP("template-files", "t", []string{"README.md.gotmpl"}, "gotemplate file paths relative to each chart directory from which documentation will be generated")
-	command.PersistentFlags().StringSliceP("custom-values-files", "f", []string{}, "additional values files to search for")
+	command.PersistentFlags().StringSliceP("custom-values-file", "f", []string{}, "additional values file to search for")
 
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("HELM_DOCS")

--- a/cmd/helm-docs/main.go
+++ b/cmd/helm-docs/main.go
@@ -45,7 +45,7 @@ func helmDocs(cmd *cobra.Command, _ []string) {
 		fullChartSearchRoot = path.Join(cwd, chartSearchRoot)
 	}
 
-	customValuesFiles := viper.GetStringSlice("custom-values-files")
+	customValuesFiles := viper.GetStringSlice("custom-values-file")
 	log.Debugf("Searching for custom values files called [%s]", strings.Join(customValuesFiles, ", "))
 
 	chartDirs, err := helm.FindChartDirectories(fullChartSearchRoot)

--- a/cmd/helm-docs/main.go
+++ b/cmd/helm-docs/main.go
@@ -14,9 +14,9 @@ import (
 	"github.com/norwoodj/helm-docs/pkg/helm"
 )
 
-func retrieveInfoAndPrintDocumentation(chartDirectory string, chartSearchRoot string, templateFiles []string, waitGroup *sync.WaitGroup, dryRun bool) {
+func retrieveInfoAndPrintDocumentation(chartDirectory string, chartSearchRoot string, templateFiles []string, customValuesFiles []string, waitGroup *sync.WaitGroup, dryRun bool) {
 	defer waitGroup.Done()
-	chartDocumentationInfo, err := helm.ParseChartInformation(path.Join(chartSearchRoot, chartDirectory))
+	chartDocumentationInfo, err := helm.ParseChartInformation(path.Join(chartSearchRoot, chartDirectory), customValuesFiles)
 
 	if err != nil {
 		log.Warnf("Error parsing information for chart %s, skipping: %s", chartDirectory, err)
@@ -45,6 +45,9 @@ func helmDocs(cmd *cobra.Command, _ []string) {
 		fullChartSearchRoot = path.Join(cwd, chartSearchRoot)
 	}
 
+	customValuesFiles := viper.GetStringSlice("custom-values-files")
+	log.Debugf("Searching for custom values files called [%s]", strings.Join(customValuesFiles, ", "))
+
 	chartDirs, err := helm.FindChartDirectories(fullChartSearchRoot)
 	if err != nil {
 		log.Errorf("Error finding chart directories: %s", err)
@@ -64,9 +67,9 @@ func helmDocs(cmd *cobra.Command, _ []string) {
 
 		// On dry runs all output goes to stdout, and so as to not jumble things, generate serially
 		if dryRun {
-			retrieveInfoAndPrintDocumentation(c, fullChartSearchRoot, templateFiles, &waitGroup, dryRun)
+			retrieveInfoAndPrintDocumentation(c, fullChartSearchRoot, templateFiles, customValuesFiles, &waitGroup, dryRun)
 		} else {
-			go retrieveInfoAndPrintDocumentation(c, fullChartSearchRoot, templateFiles, &waitGroup, dryRun)
+			go retrieveInfoAndPrintDocumentation(c, fullChartSearchRoot, templateFiles, customValuesFiles, &waitGroup, dryRun)
 		}
 	}
 

--- a/pkg/document/model.go
+++ b/pkg/document/model.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"strconv"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/norwoodj/helm-docs/pkg/helm"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
@@ -64,28 +64,47 @@ func getSortedValuesTableRows(documentRoot *yaml.Node, chartValuesDescriptions m
 	return valuesTableRows, nil
 }
 
-
 func getChartTemplateData(chartDocumentationInfo helm.ChartDocumentationInfo, helmDocsVersion string) (chartTemplateData, error) {
-	// handle empty values file case
-	if chartDocumentationInfo.ChartValues.Kind == 0 {
+	var valuesTableRows []valueRow
+
+	// TODO: wrap this with a loop through the list of ChartValues
+	for _, chartValues := range chartDocumentationInfo.ChartValues {
+		// handle empty values file case
+		if chartValues.ValuesFileContents.Kind == 0 {
+			continue
+		}
+
+		if chartValues.ValuesFileContents.Kind != yaml.DocumentNode {
+			return chartTemplateData{}, fmt.Errorf("invalid node kind supplied: %d", chartValues.ValuesFileContents.Kind)
+		}
+		if chartValues.ValuesFileContents.Content[0].Kind != yaml.MappingNode {
+			return chartTemplateData{}, fmt.Errorf("values file must resolve to a map, not %s", strconv.Itoa(int(chartValues.ValuesFileContents.Kind)))
+		}
+
+		rows, err := getSortedValuesTableRows(chartValues.ValuesFileContents.Content[0], *chartValues.ValuesDescriptions)
+		if err != nil {
+			return chartTemplateData{}, err
+		}
+
+		separatorRow := valueRow{
+			Key:             "---",
+			Type:            "---",
+			AutoDefault:     "---",
+			Default:         "---",
+			AutoDescription: "---",
+			Description:     chartValues.ValuesFileName,
+		}
+
+		valuesTableRows = append(valuesTableRows, separatorRow)
+		valuesTableRows = append(valuesTableRows, rows...)
+	}
+
+	if valuesTableRows == nil {
 		return chartTemplateData{
 			ChartDocumentationInfo: chartDocumentationInfo,
 			HelmDocsVersion:        helmDocsVersion,
 			Values:                 make([]valueRow, 0),
 		}, nil
-	}
-
-	if chartDocumentationInfo.ChartValues.Kind != yaml.DocumentNode {
-		return chartTemplateData{}, fmt.Errorf("invalid node kind supplied: %d", chartDocumentationInfo.ChartValues.Kind)
-	}
-	if chartDocumentationInfo.ChartValues.Content[0].Kind != yaml.MappingNode {
-		return chartTemplateData{}, fmt.Errorf("values file must resolve to a map, not %s", strconv.Itoa(int(chartDocumentationInfo.ChartValues.Kind)))
-	}
-
-	valuesTableRows, err := getSortedValuesTableRows(chartDocumentationInfo.ChartValues.Content[0], chartDocumentationInfo.ChartValuesDescriptions)
-
-	if err != nil {
-		return chartTemplateData{}, err
 	}
 
 	return chartTemplateData{

--- a/pkg/document/model.go
+++ b/pkg/document/model.go
@@ -67,7 +67,6 @@ func getSortedValuesTableRows(documentRoot *yaml.Node, chartValuesDescriptions m
 func getChartTemplateData(chartDocumentationInfo helm.ChartDocumentationInfo, helmDocsVersion string) (chartTemplateData, error) {
 	var valuesTableRows []valueRow
 
-	// TODO: wrap this with a loop through the list of ChartValues
 	for _, chartValues := range chartDocumentationInfo.ChartValues {
 		// handle empty values file case
 		if chartValues.ValuesFileContents.Kind == 0 {

--- a/pkg/document/model.go
+++ b/pkg/document/model.go
@@ -87,15 +87,18 @@ func getChartTemplateData(chartDocumentationInfo helm.ChartDocumentationInfo, he
 		}
 
 		separatorRow := valueRow{
-			Key:             "---",
+			Key:             fmt.Sprintf("**Defaults for values file \"%s\":**", chartValues.ValuesFileName),
 			Type:            "---",
 			AutoDefault:     "---",
 			Default:         "---",
 			AutoDescription: "---",
-			Description:     chartValues.ValuesFileName,
+			Description:     "---",
 		}
 
-		valuesTableRows = append(valuesTableRows, separatorRow)
+		if len(chartDocumentationInfo.ChartValues) > 1 {
+			valuesTableRows = append(valuesTableRows, separatorRow)
+		}
+
 		valuesTableRows = append(valuesTableRows, rows...)
 	}
 

--- a/pkg/helm/comment.go
+++ b/pkg/helm/comment.go
@@ -17,7 +17,7 @@ func ParseComment(commentLines []string) (string, ChartValueDescription) {
 		break
 	}
 
-	for _, line := range commentLines[docStartIdx+ 1:] {
+	for _, line := range commentLines[docStartIdx+1:] {
 		defaultCommentMatch := defaultValueRegex.FindStringSubmatch(line)
 
 		if len(defaultCommentMatch) > 1 {


### PR DESCRIPTION
This adds a new argument, `--custom-values-file`, which can be used multiple times to specify a path (**relative to chart directories**) to a custom values file which will be parsed **as well as** the default `values.yaml` file.

If `helm-docs` detects that a chart contains one or more of these custom values files, the final values table in the README markdown will render multiple sets of keys/types/descriptions and will include separator rows to distinguish between different sets of values.